### PR TITLE
Przeniesienie tekstów do słowników i18n

### DIFF
--- a/AZS.js
+++ b/AZS.js
@@ -4,6 +4,7 @@ import AZSActorSheet from './module/sheets/AZSActorSheet.js';
 
 async function preloadHandlebarsTemplates() {
   const templatePaths = [
+    'systems/AZS/templates/partials/description.hbs',
     'systems/AZS/templates/partials/atrybuty-postaci.hbs',
     'systems/AZS/templates/partials/bieglosci-postaci.hbs',
     'systems/AZS/templates/partials/zasoby-postaci.hbs',

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -2,5 +2,6 @@ export default {
   transform: {
     "^.+\\.jsx?$": "babel-jest"
   },
-  setupFiles: ['./tests/setup.js']
+  setupFilesAfterEnv: ['./tests/setup.js'],
+  testEnvironment: 'jest-environment-jsdom',
 };

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,87 @@
 {
   "AZS": {
+    "pc.sheet": {
+      "name": "Name",
+      "archetype": "Archetype",
+      "kin": "Kin"
+    },
+    "pc.sheet.notes": {
+      "header": "Biography"
+    },
+    "pc.sheet.level": {
+      "header": "Level",
+      "xp": "XP"
+    },
+    "pc.sheet.attributes": {
+      "header": "Attributes",
+      "life": "life",
+      "mana": "mana",
+      "strength": "strength",
+      "dexterity": "dexterity",
+      "magic": "magic",
+      "speed": "speed",
+      "move": "move"
+    },
+    "pc.sheet.skills": {
+      "header": "Skills"
+    },
+    "pc.sheet.resources": {
+      "header": "Resources",
+      "ammo.header": "Ammo",
+      "armor.header": "Armor",
+      "torch.header": "Torch",
+      "wound.header": "Wound",
+      "supplies.header": "Supplies",
+      "tools.header": "Tools",
+      "components.header": "Components"
+    },
+    "pc.sheet.backpack": {
+      "header": "Backpack",
+      "add.item": "Add Item",
+      "slots": "Slots"
+    },
+    "item.sheet": {
+      "description.header": "Description",
+      "description.default-content": "Item Description"
+    },
+    "item.weapon.sheet": {
+      "attack.header": "Attack",
+      "defense.header": "Defense",
+      "type.header": "Type",
+      "attributes.header": "Attributes",
+      "description.header": "Description",
+      "description.default-content": "Weapon Description"
+    },
+    "item.armor.sheet": {
+      "armor-class.header": "AC",
+      "max-armor-class.header": "AC max",
+      "slots.header": "Slots",
+      "description.header": "Description",
+      "description.default-content": "Armor Description"
+    },
+    "item.spell-book.sheet": {
+      "header": "Spell",
+      "description.header": "Description",
+      "description.default-content": "Spell Description"
+    },
+    "treasure-dice.sheet": {
+      "formula.header": "Formula"
+    },
+    "npc.sheet": {
+      "life": "Life",
+      "armor": "Armor",
+      "move": "Move",
+      "challenge-rating": "CR",
+      "xp": "XP"
+    },
+    "npc.sheet.skills": {
+      "header": "Skills",
+      "description.header": "Description",
+      "description.default-content": "Skill Description"
+    },
+    "loot-bag.sheet": {
+      "header": "Dice in the bag"
+    },
     "bieglosc": {
       "brak": "",
       "szermierka": "szermierka",
@@ -47,33 +129,29 @@
       "magiczna": "magiczna"
     },
     "tom": {
-      "czar": "czar"
+      "czar": "spell"
     },
     "zbroja": {
-      "pancerz": "pancerz",
+      "pancerz": "armor",
       "pp": "PP",
       "ppmax": "PP max"
     },
     "ogolne": {},
     "rasa": {
-      "czlowiek": "człowiek",
+      "czlowiek": "human",
       "elf": "elf",
-      "ork": "ork",
-      "krasnolud": "krasnolud"
+      "ork": "orc",
+      "krasnolud": "dwarf"
     },
     "pochodzenie": {
-      "wojownik": "wojownik",
-      "lotr": "łotr",
-      "mag": "mag",
-      "podroznik": "podróżnik"
-    },
-    "kartaPostaci": {
-      "dodajPrzedmiot": "Dodaj przedmiot",
-      "nowyPrzedmiot": "Nowy przedmiot"
+      "wojownik": "warrior",
+      "lotr": "rouge",
+      "mag": "wizard",
+      "podroznik": "adventurer"
     },
     "typBieglosci": {
-      "umiejetnosc": "umiejętność",
-      "czar": "czar"
+      "umiejetnosc": "skill",
+      "czar": "spell"
     }
   }
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -1,5 +1,87 @@
 {
   "AZS": {
+    "pc.sheet": {
+      "name": "Imię",
+      "archetype": "Artchetyp",
+      "kin": "Rasa"
+    },
+    "pc.sheet.notes": {
+      "header": "Biografia postaci"
+    },
+    "pc.sheet.level": {
+      "header": "Poziom",
+      "xp": "PD"
+    },
+    "pc.sheet.attributes": {
+      "header": "Atrybuty",
+      "life": "życie",
+      "mana": "mana",
+      "strength": "siła",
+      "dexterity": "sprawność",
+      "magic": "magia",
+      "speed": "szybkość",
+      "move": "ruch"
+    },
+    "pc.sheet.skills": {
+      "header": "Biegłości"
+    },
+    "pc.sheet.resources": {
+      "header": "Zasoby",
+      "ammo.header": "Amunicja",
+      "armor.header": "Pancerz",
+      "torch.header": "Pochodnia",
+      "wound.header": "Rana",
+      "supplies.header": "Zapasy",
+      "tools.header": "Narzędzia",
+      "components.header": "Komponenty"
+    },
+    "pc.sheet.backpack": {
+      "header": "Plecak",
+      "add.item": "Dodaj przedmiot",
+      "slots": "Sloty"
+    },
+    "item.sheet": {
+      "description.header": "Opis",
+      "description.default-content": "Opis Przedmiotu"
+    },
+    "item.weapon.sheet": {
+      "attack.header": "Atak",
+      "defense.header": "Obrona",
+      "type.header": "Typ",
+      "attributes.header": "Cechy",
+      "description.header": "Opis",
+      "description.default-content": "Opis Broni"
+    },
+    "item.armor.sheet": {
+      "armor-class.header": "PP",
+      "max-armor-class.header": "PP max",
+      "slots.header": "Sloty",
+      "description.header": "Opis",
+      "description.default-content": "Opis Zbroi"
+    },
+    "item.spell-book.sheet": {
+      "header": "Czar",
+      "description.header": "Opis",
+      "description.default-content": "Opis Zaklęcia"
+    },
+    "treasure-dice.sheet": {
+      "formula.header": "Formuła rzutu"
+    },
+    "npc.sheet": {
+      "life": "Życie",
+      "armor": "Pancerz",
+      "move": "Ruch",
+      "challenge-rating": "SW",
+      "xp": "PD"
+    },
+    "npc.sheet.skills": {
+      "header": "Zdolności",
+      "description.header": "Opis",
+      "description.default-content": "Opis Zdolności"
+    },
+    "loot-bag.sheet": {
+      "header": "Kości w torbie"
+    },
     "bieglosc": {
       "brak": "",
       "szermierka": "szermierka",
@@ -66,10 +148,6 @@
       "lotr": "łotr",
       "mag": "mag",
       "podroznik": "podróżnik"
-    },
-    "kartaPostaci": {
-      "dodajPrzedmiot": "Dodaj przedmiot",
-      "nowyPrzedmiot": "Nowy przedmiot"
     },
     "typBieglosci": {
       "umiejetnosc": "umiejętność",

--- a/module/config.js
+++ b/module/config.js
@@ -61,11 +61,6 @@ AZS.bronSpecjalne = {
   bezsily: 'nie używa siły',
 };
 
-AZS.kartaPostaci = {
-  nowyPrzedmiot: 'AZS.kartaPostaci.nowyPrzedmiot',
-  dodajPrzedmiot: 'AZS.kartaPostaci.dodajPrzedmiot',
-};
-
 AZS.typBieglosci = {
   umiejetnosc: 'AZS.typBieglosci.umiejetnosc',
   czar: 'AZS.typBieglosci.czar',

--- a/module/sheets/AZSActorSheet.js
+++ b/module/sheets/AZSActorSheet.js
@@ -128,7 +128,7 @@ export default class AZSActorSheet extends ActorSheet {
   _onItemCreate(event) {
     event.preventDefault();
     const type = event.currentTarget.dataset.type;
-    const name = game.i18n.localize('AZS.kartaPostaci.nowyPrzedmiot');
+    const name = game.i18n.localize('AZS.pc.sheet.backpack.add.item');
 
     const itemData = {
       name,

--- a/module/sheets/AZSActorSheet.test.js
+++ b/module/sheets/AZSActorSheet.test.js
@@ -1,7 +1,10 @@
 import { isObject, isString } from 'lodash';
+import userEvent from '@testing-library/user-event';
 
 import { Actor } from '../../tests/mocks';
 import AZSActorSheet from './AZSActorSheet';
+
+const getDOM = () => document.createElement('div');
 
 describe('AZSActorSheet', () => {
   it('exists', () => {
@@ -60,5 +63,20 @@ describe('AZSActorSheet', () => {
     const actorSheet = new AZSActorSheet(new Actor(actorType));
 
     expect(actorSheet.getData()).not.toEqual({});
+  });
+
+  it('on attribute roll', async () => {
+    const user = userEvent.setup();
+    const buttonSelector = '.atrybut-roll';
+    const button = document.createElement('button');
+
+    button.innerHTML = 'Roll';
+    button.classList.add('atrybut-roll');
+
+    const screen = getDOM(button);
+
+    await user.click(screen.querySelector(buttonSelector));
+
+    expect(user).toBeDefined();
   });
 });

--- a/module/sheets/__snapshots__/example-testing-library.test.js.snap
+++ b/module/sheets/__snapshots__/example-testing-library.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`examples of some things 1`] = `
+<div>
+  
+    
+  <label
+    for="username"
+  >
+    Username
+  </label>
+  
+    
+  <input
+    id="username"
+  />
+  
+    
+  <button>
+    Print Username
+  </button>
+  
+  
+  <div>
+    
+        
+    <div
+      data-testid="printed-username"
+    >
+      Ada Lovelace
+    </div>
+    
+      
+  </div>
+</div>
+`;

--- a/module/sheets/example-testing-library.test.js
+++ b/module/sheets/example-testing-library.test.js
@@ -1,0 +1,63 @@
+// query utilities:
+import {
+  getByLabelText,
+  getByText,
+  getByTestId,
+  queryByTestId,
+  // Tip: all queries are also exposed on an object
+  // called "queries" which you could import here as well
+  waitFor,
+} from '@testing-library/dom';
+// adds special assertions like toHaveTextContent
+// import '@testing-library/jest-dom';
+
+function getExampleDOM() {
+  // This is just a raw example of setting up some DOM
+  // that we can interact with. Swap this with your UI
+  // framework of choice 😉
+  const div = document.createElement('div');
+  div.innerHTML = `
+    <label for="username">Username</label>
+    <input id="username" />
+    <button>Print Username</button>
+  `;
+  const button = div.querySelector('button');
+  const input = div.querySelector('input');
+  button.addEventListener('click', () => {
+    // let's pretend this is making a server request, so it's async
+    // (you'd want to mock this imaginary request in your unit tests)...
+    setTimeout(() => {
+      const printedUsernameContainer = document.createElement('div');
+      printedUsernameContainer.innerHTML = `
+        <div data-testid="printed-username">${input.value}</div>
+      `;
+      div.appendChild(printedUsernameContainer);
+    }, Math.floor(Math.random() * 200));
+  });
+  return div;
+}
+
+it('examples of some things', async () => {
+  const famousProgrammerInHistory = 'Ada Lovelace';
+  const container = getExampleDOM();
+
+  // Get form elements by their label text.
+  // An error will be thrown if one cannot be found (accessibility FTW!)
+  const input = getByLabelText(container, 'Username');
+  input.value = famousProgrammerInHistory;
+
+  // Get elements by their text, just like a real user does.
+  getByText(container, 'Print Username').click();
+
+  await waitFor(() =>
+    expect(queryByTestId(container, 'printed-username')).toBeTruthy()
+  );
+
+  // getByTestId and queryByTestId are an escape hatch to get elements
+  // by a test id (could also attempt to get this element by its text)
+  expect(getByTestId(container, 'printed-username')).toHaveTextContent(
+    famousProgrammerInHistory
+  );
+  // jest snapshots work great with regular DOM nodes!
+  expect(container).toMatchSnapshot();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.9",
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
+        "@testing-library/dom": "^9.3.0",
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/user-event": "^14.4.3",
         "babel-jest": "^29.5.0",
         "eslint": "^8.40.0",
         "eslint-config-prettier": "^8.8.0",
@@ -17,6 +20,7 @@
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-promise": "^6.1.1",
         "jest": "^29.5.0",
+        "jest-environment-jsdom": "^29.5.0",
         "lodash": "^4.17.21",
         "node-notifier": "^10.0.1",
         "prettier": "2.8.8",
@@ -25,6 +29,12 @@
         "stylelint-config-standard": "^33.0.0",
         "stylelint-config-standard-scss": "^9.0.0"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
+      "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -90,23 +100,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@babel/core/node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -118,12 +111,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@babel/core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
       "version": "6.3.0",
@@ -290,29 +277,6 @@
       "peerDependencies": {
         "@babel/core": "^7.4.0-0"
       }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
       "version": "6.3.0",
@@ -1856,23 +1820,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@babel/traverse/node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1881,12 +1828,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/@babel/traverse/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@babel/types": {
       "version": "7.21.5",
@@ -2017,29 +1958,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/@eslint/js": {
       "version": "8.40.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.40.0.tgz",
@@ -2062,29 +1980,6 @@
       "engines": {
         "node": ">=10.10.0"
       }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
@@ -2763,6 +2658,120 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.0.tgz",
+      "integrity": "sha512-Dffe68pGwI6WlLRYR2I0piIkyole9cSBH5jGQKCGMRpHW5RHCqAUaqc2Kv0tUyd4dU4DLPKhJIjyKOnjv4tuUw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "5.16.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz",
+      "integrity": "sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.0.1",
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -2837,6 +2846,27 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
+      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -2873,6 +2903,21 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/testing-library__jest-dom": {
+      "version": "5.14.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz",
+      "integrity": "sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
+      }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
+      "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
@@ -2888,6 +2933,12 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "dev": true
+    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -2900,6 +2951,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2907,6 +2968,27 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -2981,6 +3063,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-query": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-equal": "^2.0.5"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.0",
@@ -3076,6 +3167,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -3465,6 +3562,18 @@
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3589,6 +3698,12 @@
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3599,6 +3714,61 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decamelize": {
@@ -3635,11 +3805,46 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
+    },
+    "node_modules/deep-equal": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.1.tgz",
+      "integrity": "sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==",
+      "dev": true,
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.2",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.0",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3670,6 +3875,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3723,6 +3937,24 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.394",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.394.tgz",
@@ -3746,6 +3978,18 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3804,15 +4048,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-abstract/node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3877,6 +4127,79 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.0.0.tgz",
+      "integrity": "sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==",
+      "dev": true,
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/escodegen/node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/eslint": {
@@ -4283,23 +4606,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4327,12 +4633,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/eslint/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/eslint/node_modules/path-exists": {
       "version": "4.0.0",
@@ -4567,6 +4867,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -4634,6 +4940,20 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4683,13 +5003,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -4929,6 +5250,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4947,6 +5280,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -4954,6 +5314,18 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -5069,15 +5441,17 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/internal-slot/node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5092,20 +5466,6 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-array-buffer/node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5229,6 +5589,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -5283,6 +5652,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -5295,6 +5670,15 @@
       "engines": {
         "node": ">= 0.4"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -5372,6 +5756,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -5379,6 +5772,19 @@
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5395,6 +5801,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5487,29 +5899,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/istanbul-reports": {
       "version": "3.1.5",
@@ -5889,6 +6278,33 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.5.0.tgz",
+      "integrity": "sha512-/KG8yEK4aN8ak56yFVdqFDzKNHgF4BAymCx2LbPNPsUshUlfAl0eX402Xm1pt+eoG9SLZEUVifqXtX8SK74KCw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -6452,6 +6868,51 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -6586,6 +7047,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/makeerror": {
@@ -6885,6 +7355,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -6946,6 +7437,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.6",
@@ -7048,11 +7545,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.4.tgz",
+      "integrity": "sha512-NHj4rzRo0tQdijE9ZqAx6kYDcoRwYwSYzCA8MY3JzfxlrvEU0jhnhJT9BhqhJs7I/dKcrDm6TyulaRqZPIhN5g==",
+      "dev": true
+    },
     "node_modules/object-inspect": {
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7142,12 +7661,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/optionator/node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7197,6 +7710,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-is-absolute": {
@@ -7483,6 +8008,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -7507,6 +8038,12 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7690,6 +8227,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -7813,6 +8356,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/sass": {
       "version": "1.62.1",
@@ -7973,6 +8522,18 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/shebang-command": {
@@ -8154,6 +8715,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
+      "dev": true,
+      "dependencies": {
+        "internal-slot": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string-length": {
@@ -8418,23 +8991,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/stylelint/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/stylelint/node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -8513,12 +9069,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/stylelint/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
     "node_modules/stylelint/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -8595,6 +9145,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "node_modules/table": {
@@ -8691,6 +9247,33 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/trim-newlines": {
@@ -8825,6 +9408,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
@@ -8862,6 +9454,16 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -8909,6 +9511,18 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -8916,6 +9530,49 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -8941,6 +9598,21 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "dependencies": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8993,6 +9665,42 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",
+    "@testing-library/dom": "^9.3.0",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/user-event": "^14.4.3",
     "babel-jest": "^29.5.0",
     "eslint": "^8.40.0",
     "eslint-config-prettier": "^8.8.0",
@@ -25,6 +28,7 @@
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-promise": "^6.1.1",
     "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "lodash": "^4.17.21",
     "node-notifier": "^10.0.1",
     "prettier": "2.8.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format": "npx prettier --write .",
     "lint:ci": "npm run lint:code:ci && npm run lint:styles:ci",
     "lint:code:ci": "npx eslint module --fix",
-    "lint:styles:ci": "npx stylelint \"**/*.less\" --fix"
+    "lint:styles:ci": "npx stylelint \"src/styles/**/*.scss\""
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/template.json
+++ b/template.json
@@ -85,7 +85,7 @@
     ],
     "templates": {
       "podstawoweInformacje": {
-        "opis": "Opis przedmiotu",
+        "opis": "",
         "sloty": 0
       }
     },

--- a/templates/partials/atrybuty-postaci.hbs
+++ b/templates/partials/atrybuty-postaci.hbs
@@ -1,6 +1,10 @@
-<h3>Atrybuty</h3>
+<h3>
+  {{localize 'AZS.pc.sheet.attributes.header'}}
+</h3>
 <div class='atrybuty-partial'>
-  <div class='padding-lewo atr zycie opis'>życie</div>
+  <div class='padding-lewo atr zycie opis'>
+    {{localize 'AZS.pc.sheet.attributes.life'}}
+  </div>
   <div class='atr zycie wartosc zasob'>
     <input
       class='input-zasob prawo'
@@ -22,7 +26,9 @@
       size='2'
     />
   </div>
-  <div class='padding-lewo atr mana opis'>mana</div>
+  <div class='padding-lewo atr mana opis'>
+    {{localize 'AZS.pc.sheet.attributes.mana'}}
+  </div>
   <div class='atr mana wartosc zasob'>
     <input
       class='input-zasob prawo'
@@ -48,7 +54,9 @@
     class='atrybut-roll opis padding-lewo'
     data-roll='d20+{{actor.system.sila}}'
     data-label='Test siły'
-  >siła</a>
+  >
+    {{localize 'AZS.pc.sheet.attributes.strength'}}
+  </a>
   <div class='atr sila wartosc srodek'>
     <input
       class='input-stat'
@@ -64,7 +72,9 @@
     class='atrybut-roll opis padding-lewo'
     data-roll='d20+{{actor.system.sprawnosc}}'
     data-label='Test sprawności'
-  >sprawność</a>
+  >
+    {{localize 'AZS.pc.sheet.attributes.dexterity'}}
+  </a>
   <div class='atr sprawnosc wartosc srodek'>
     <input
       class='input-stat'
@@ -80,7 +90,9 @@
     class='atrybut-roll opis padding-lewo'
     data-roll='d20+{{actor.system.magia}}'
     data-label='Test magii'
-  >magia</a>
+  >
+    {{localize 'AZS.pc.sheet.attributes.magic'}}
+  </a>
   <div class='atr magia wartosc srodek'>
     <input
       class='input-stat'
@@ -96,7 +108,9 @@
     class='atrybut-roll opis padding-lewo'
     data-roll='d20+{{actor.system.szybkosc}}'
     data-label='Test szybkości'
-  >szybkość</a>
+  >
+    {{localize 'AZS.pc.sheet.attributes.speed'}}
+  </a>
   <div class='atr szybkosc wartosc srodek'>
     <input
       class='input-stat'
@@ -108,7 +122,9 @@
       size='1'
     />
   </div>
-  <div class='atr ruch opis padding-lewo'>ruch</div>
+  <div class='atr ruch opis padding-lewo'>
+    {{localize 'AZS.pc.sheet.attributes.move'}}
+  </div>
   <div class='atr ruch wartosc srodek'>
     <input
       class='input-stat'

--- a/templates/partials/bieglosci-postaci.hbs
+++ b/templates/partials/bieglosci-postaci.hbs
@@ -1,5 +1,7 @@
 <div class='bieglosci_partial'>
-  <h3>Biegłości</h3>
+  <h3>
+    {{localize 'AZS.pc.sheet.skills.header'}}
+  </h3>
   <section class='lista-bieglosci'>
     {{#each bieglosci as |bieglosc|}}
       <div class='item padding-lewo' data-item-id='{{id}}'>

--- a/templates/partials/description.hbs
+++ b/templates/partials/description.hbs
@@ -1,0 +1,5 @@
+{{#if item.system.opis}}
+  {{~item.system.opis~}}
+{{else}}
+  {{~localize description~}}
+{{/if}}

--- a/templates/partials/plecak-postaci.hbs
+++ b/templates/partials/plecak-postaci.hbs
@@ -1,32 +1,34 @@
-<h3>Plecak</h3>
+<h3>
+  {{localize 'AZS.pc.sheet.backpack.header'}}
+</h3>
 <div class='plecak-partial'>
   <div class='odstepdol padding-lewo'>
     <i class='fa-regular fa-plus'></i>
     <a
       class='item-create'
       data-type='bron'
-      title='{{localize "AZS.kartaPostaci.dodajPrzedmiot"}}'
+      title='{{localize "AZS.pc.sheet.backpack.add.item"}}'
     >
       <i class='fa-regular fa-sword'></i>
     </a>
     <a
       class='item-create'
       data-type='zbroja'
-      title='{{localize "AZS.kartaPostaci.dodajPrzedmiot"}}'
+      title='{{localize "AZS.pc.sheet.backpack.add.item"}}'
     >
       <i class='fa-regular fa-shield'></i>
     </a>
     <a
       class='item-create'
       data-type='tom'
-      title='{{localize "AZS.kartaPostaci.dodajPrzedmiot"}}'
+      title='{{localize "AZS.pc.sheet.backpack.add.item"}}'
     >
       <i class='fa-regular fa-book'></i>
     </a>
     <a
       class='item-create'
       data-type='ogolne'
-      title='{{localize "AZS.kartaPostaci.dodajPrzedmiot"}}'
+      title='{{localize "AZS.pc.sheet.backpack.add.item"}}'
     >
       <i class='fa-regular fa-sack'></i>
     </a>
@@ -43,7 +45,7 @@
   </section>
   <div style='display: grid;grid-template-columns: 1fr 1fr;'>
     <div class='opis' style='text-align:left; padding-left: 5px;'>
-      Sloty:
+      {{localize 'AZS.pc.sheet.backpack.slots'}}:
       <input
         class='input-zloto'
         name='system.sloty'

--- a/templates/partials/zasoby-postaci.hbs
+++ b/templates/partials/zasoby-postaci.hbs
@@ -2,7 +2,9 @@
   <div
     class='zasoby label opis srodek'
     style='padding-top: 10px;'
-  >Amunicja</div>
+  >
+    {{localize 'AZS.pc.sheet.resources.ammo.header'}}
+  </div>
   <div class='zasobInputDiv'><input
       class='input-zasob prawo'
       name='system.amunicja.value'
@@ -17,7 +19,9 @@
     class='lewo'
     style='padding-top: 4px;'
   >{{actor.system.amunicja.max}}</div>
-  <div class='zasoby label opis srodek'>Pancerz</div>
+  <div class='zasoby label opis srodek'>
+    {{localize 'AZS.pc.sheet.resources.armor.header'}}
+  </div>
   <div class='zasobInputDiv'><input
       class='input-zasob prawo'
       name='system.pp.value'
@@ -37,8 +41,11 @@
       maxlength='1'
       size='1'
     /></div>
-  <div class='zasoby label opis srodek'>Pochodnia</div>
-  <div class='zasobInputDiv'><input
+  <div class='zasoby label opis srodek'>
+    {{localize 'AZS.pc.sheet.resources.torch.header'}}
+  </div>
+  <div class='zasobInputDiv'>
+    <input
       class='input-zasob prawo'
       name='system.pochodnia.value'
       type='text'
@@ -46,18 +53,28 @@
       data-dtype='Number'
       maxlength='1'
       size='1'
-    /></div>
+    />
+  </div>
   <div class='srodek' style='padding-top: 4px;'>/</div>
   <div
     class='lewo'
     style='padding-top: 4px;'
-  >{{actor.system.pochodnia.max}}</div>
-  <div class='zasoby label opis srodek'>Rana</div>
-  <div class='zasoby label srodek'><label><input
+  >
+    {{actor.system.pochodnia.max}}
+  </div>
+  <div class='zasoby label opis srodek'>
+    {{localize 'AZS.pc.sheet.resources.wound.header'}}
+  </div>
+  <div class='zasoby label srodek'>
+    <label>
+      <input
         name='system.rana'
         type='checkbox'
         {{checked actor.system.rana}}
-      /><span class='czekbox2'><i
-          class='opis fa-regular fa-hand'
-        ></i></span></label></div>
+      />
+      <span class='czekbox2'>
+        <i class='opis fa-regular fa-hand'></i>
+      </span>
+    </label>
+  </div>
 </div>

--- a/templates/partials/zasoby2-postaci.hbs
+++ b/templates/partials/zasoby2-postaci.hbs
@@ -1,7 +1,17 @@
-<div class='zasoby2-head srodek'><h3>Zasoby</h3></div>
-<div class='zapasy-nag opis srodek'>Zapasy</div>
-<div class='narzedzia-nag opis srodek'>Narzędzia</div>
-<div class='komponenty-nag opis srodek'>Komponenty</div>
+<div class='zasoby2-head srodek'>
+  <h3>
+    {{localize 'AZS.pc.sheet.resources.header'}}
+  </h3>
+</div>
+<div class='zapasy-nag opis srodek'>
+  {{localize 'AZS.pc.sheet.resources.supplies.header'}}
+</div>
+<div class='narzedzia-nag opis srodek'>
+  {{localize 'AZS.pc.sheet.resources.tools.header'}}
+</div>
+<div class='komponenty-nag opis srodek'>
+  {{localize 'AZS.pc.sheet.resources.components.header'}}
+</div>
 <div class='srodek zapasy-val-1 zasob'>
   <div class='srodek'><label><input
         name='system.zapasy.zapas1'

--- a/templates/partials/zdolnosci-przeciwnika.hbs
+++ b/templates/partials/zdolnosci-przeciwnika.hbs
@@ -6,8 +6,6 @@
       style='padding-bottom: 5px;'
     >
       <a class='item-edit' style='font-weight: bold;'>{{name}}</a>
-      -
-      {{system.opis}}
       <a class='item-delete'>
         <i class='fa-regular fa-xmark'></i>
       </a>

--- a/templates/sheets/bron-sheet.html
+++ b/templates/sheets/bron-sheet.html
@@ -19,9 +19,15 @@
       />
     </div>
     <div class="bron-staty">
-      <div class="srodek wiekszy-font">Atak</div>
-      <div class="srodek wiekszy-font">Obrona</div>
-      <div class="srodek wiekszy-font">Typ</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.weapon.sheet.attack.header'}}
+      </div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.weapon.sheet.defense.header'}}
+      </div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.weapon.sheet.type.header'}}
+      </div>
       <div class="srodek item wiekszy-font">
         <input
           name="system.atak"
@@ -60,7 +66,9 @@
       </div>
     </div>
     <div class="bron-wlasciwosci">
-      <div class="srodek wiekszy-font srodek-kolumn">Cechy</div>
+      <div class="srodek wiekszy-font srodek-kolumn">
+        {{localize 'AZS.item.weapon.sheet.attributes.header'}}
+      </div>
       <div>
         <select class="item-select" name="system.specjalne1">
           {{#select item.system.specjalne1}} {{#each config.bronSpecjalne as
@@ -95,14 +103,17 @@
       </div>
     </div>
     <div class="bron-opis">
-      <div class="srodek wiekszy-font">Opis</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.weapon.sheet.description.header'}}
+      </div>
       <div style="padding-right: 5px; padding-left: 5px">
         <textarea
           name="system.opis"
           style="background: none; border: none; height: 75px; width: 285px"
-        >
-{{item.system.opis}}</textarea
-        >
+        >{{>
+          "systems/AZS/templates/partials/description.hbs"
+          description='AZS.item.weapon.sheet.description.default-content'
+        }}</textarea>
       </div>
     </div>
   </div>

--- a/templates/sheets/koscSkarbu-sheet.html
+++ b/templates/sheets/koscSkarbu-sheet.html
@@ -22,14 +22,16 @@
       />
     </div>
     <div class="srodek-kolumn">
-      <div class="srodek wiekszy-font">Formuła rzutu</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.treasure-dice.sheet.formula.header'}}
+      </div>
       <div style="padding-right: 5px; padding-left: 5px">
         <textarea
           name="system.formula"
           style="background: none; border: none; height: 75px; width: 285px"
         >
-{{item.system.formula}}</textarea
-        >
+          {{~item.system.formula~}}
+        </textarea>
       </div>
     </div>
   </div>

--- a/templates/sheets/ogolne-sheet.html
+++ b/templates/sheets/ogolne-sheet.html
@@ -22,14 +22,17 @@
       />
     </div>
     <div class="srodek-kolumn">
-      <div class="srodek wiekszy-font">Opis</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.sheet.description.header'}}
+      </div>
       <div style="padding-right: 5px; padding-left: 5px">
         <textarea
           name="system.opis"
           style="background: none; border: none; height: 75px; width: 335px"
-        >
-{{item.system.opis}}</textarea
-        >
+        >{{>
+          "systems/AZS/templates/partials/description.hbs"
+          description='AZS.item.sheet.description.default-content'
+        }}</textarea>
       </div>
     </div>
   </div>

--- a/templates/sheets/postac-sheet.html
+++ b/templates/sheets/postac-sheet.html
@@ -1,9 +1,9 @@
 <form class="{{cssClass}}" autocomplete="off">
   <div class="postac-siatka">
     <div class="postac naglowek">
-      <div><h3>Imię</h3></div>
-      <div><h3>Artchetyp</h3></div>
-      <div><h3>Rasa</h3></div>
+      <div><h3>{{localize 'AZS.pc.sheet.name'}}</h3></div>
+      <div><h3>{{localize 'AZS.pc.sheet.archetype'}}</h3></div>
+      <div><h3>{{localize 'AZS.pc.sheet.kin'}}</h3></div>
       <div class="srodek opis">{{actor.name}}</div>
       <div class="srodek">
         <select
@@ -52,16 +52,20 @@
       />
     </div>
     <div class="postac notatki">
-      <h3>Biografia postaci</h3>
+      <h3>
+        {{localize 'AZS.pc.sheet.notes.header'}}
+      </h3>
       <textarea
         name="actor.system.opis"
         style="background: none; border: none; height: 110px; width: 175px"
       >
-{{actor.system.opis}}</textarea
-      >
+        {{~actor.system.opis~}}
+      </textarea>
     </div>
     <div class="postac poziom">
-      <div class="opis padding-lewo">Poziom</div>
+      <div class="opis padding-lewo">
+        {{localize 'AZS.pc.sheet.level.header'}}
+      </div>
       <div class="atr wartosc srodek">
         <input
           class="input-stat"
@@ -73,7 +77,9 @@
           size="1"
         />
       </div>
-      <div class="opis padding-lewo">PD</div>
+      <div class="opis padding-lewo">
+        {{localize 'AZS.pc.sheet.level.xp'}}
+      </div>
       <div class="inputCyferki srodek">
         <input
           name="system.pd"

--- a/templates/sheets/przeciwnik-sheet.html
+++ b/templates/sheets/przeciwnik-sheet.html
@@ -20,11 +20,21 @@
         {{actor.name}}
       </div>
       <div class="przeciwnik-staty">
-        <div class="opis srodek">Życie</div>
-        <div class="opis srodek">Pancerz</div>
-        <div class="opis srodek">Ruch</div>
-        <div class="opis srodek">SW</div>
-        <div class="opis srodek">EXP</div>
+        <div class="opis srodek">
+          {{localize 'AZS.npc.sheet.life'}}
+        </div>
+        <div class="opis srodek">
+          {{localize 'AZS.npc.sheet.armor'}}
+        </div>
+        <div class="opis srodek">
+          {{localize 'AZS.npc.sheet.move'}}
+        </div>
+        <div class="opis srodek">
+          {{localize 'AZS.npc.sheet.challenge-rating'}}
+        </div>
+        <div class="opis srodek">
+          {{localize 'AZS.npc.sheet.xp'}}
+        </div>
         <div class="srodek zasob-potwor-2">
           <div class="prawo">
             <input
@@ -109,11 +119,11 @@
     <div class="ramka przeciwnik zdolnosci">
       <div class="srodek" style="padding-top: 2px">
         <h3>
-          Zdolności
+          {{localize 'AZS.npc.sheet.skills.header'}}
           <a
             class="item-create"
             data-type="zdolnoscPrzeciwnika"
-            title='{{localize "AZS.kartaPostaci.dodajPrzedmiot"}}'
+            title='{{localize "AZS.pc.sheet.backpack.add.item"}}'
           >
             <i
               class="fa-regular fa-plus"

--- a/templates/sheets/tom-sheet.html
+++ b/templates/sheets/tom-sheet.html
@@ -29,7 +29,9 @@
         grid-template-columns: 1fr 1fr;
       "
     >
-      <div class="wiekszy-font">Biegłość:</div>
+      <div class="wiekszy-font">
+        {{localize 'AZS.item.spell-book.sheet.header'}}
+      </div>
       <select class="item-select" name="system.czar">
         {{#select item.system.czar}} {{#each config.czar as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
@@ -37,14 +39,17 @@
       </select>
     </div>
     <div class="srodek-kolumn">
-      <div class="srodek wiekszy-font">Opis</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.spell-book.sheet.description.header'}}
+      </div>
       <div style="padding-right: 5px; padding-left: 5px">
         <textarea
           name="system.opis"
           style="background: none; border: none; height: 75px; width: 285px"
-        >
-{{item.system.opis}}</textarea
-        >
+        >{{>
+          "systems/AZS/templates/partials/description.hbs"
+          description='AZS.item.spell-book.sheet.description.default-content'
+        }}</textarea>
       </div>
     </div>
   </div>

--- a/templates/sheets/torbaNaLup-sheet.html
+++ b/templates/sheets/torbaNaLup-sheet.html
@@ -7,7 +7,9 @@
       <i class="fa-regular fa-sack"></i> {{actor.name}}
     </div>
     <div class="torba-kosci">
-      <div class="srodek wiekszy-font">Kości w torbie</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.loot-bag.sheet.header'}}
+      </div>
       <section
         class="srodek kosci-skarbow"
         style="display: grid; grid-template-columns: 1fr 1fr 1fr"

--- a/templates/sheets/zbroja-sheet.html
+++ b/templates/sheets/zbroja-sheet.html
@@ -30,9 +30,15 @@
         grid-template-rows: 1fr 1fr;
       "
     >
-      <div class="srodek wiekszy-font">PP</div>
-      <div class="srodek wiekszy-font">PP max</div>
-      <div class="srodek wiekszy-font">sloty</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.armor.sheet.armor-class.header'}}
+      </div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.armor.sheet.max-armor-class.header'}}
+      </div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.armor.sheet.slots.header'}}
+      </div>
       <div class="srodek item wiekszy-font">
         <input
           name="data.pp"
@@ -65,14 +71,17 @@
       </div>
     </div>
     <div class="srodek-kolumn">
-      <div class="srodek wiekszy-font">Opis</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.item.armor.sheet.description.header'}}
+      </div>
       <div style="padding-right: 5px; padding-left: 5px">
         <textarea
           name="data.opis"
           style="background: none; border: none; height: 75px; width: 285px"
-        >
-{{data.opis}}</textarea
-        >
+        >{{>
+          "systems/AZS/templates/partials/description.hbs"
+          description='AZS.item.armor.sheet.description.default-content'
+        }}</textarea>
       </div>
     </div>
   </div>

--- a/templates/sheets/zdolnoscPrzeciwnika-sheet.html
+++ b/templates/sheets/zdolnoscPrzeciwnika-sheet.html
@@ -22,14 +22,17 @@
       />
     </div>
     <div class="srodek-kolumn">
-      <div class="srodek wiekszy-font">Opis</div>
+      <div class="srodek wiekszy-font">
+        {{localize 'AZS.npc.sheet.skills.description.header'}}
+      </div>
       <div style="padding-right: 5px; padding-left: 5px">
         <textarea
           name="data.opis"
           style="background: none; border: none; height: 75px; width: 285px"
-        >
-{{data.opis}}</textarea
-        >
+        >{{>
+          "systems/AZS/templates/partials/description.hbs"
+          description='AZS.npc.sheet.skills.description.default-content'
+        }}</textarea>
       </div>
     </div>
   </div>

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,4 +1,10 @@
+import '@testing-library/jest-dom';
 import { ActorSheet, ItemSheet, mergeObject } from './mocks';
+
+// Object.defineProperty(navigator, 'userAgent', {
+//   get: () => undefined,
+//   configurable: true,
+// });
 
 global.ActorSheet = ActorSheet;
 global.ItemSheet = ItemSheet;


### PR DESCRIPTION
Zrobiłem nowy partial template `description.hbs`, który pomaga w podawaniu opisu, a jak go nie ma, to używa domyślnego ze słownika. Dzięki temu można uniknąć duplikacji kodu.

Użycie:

```hbs
<textarea>{{>
  "systems/AZS/templates/partials/description.hbs"
  description='AZS.item.weapon.sheet.description.default-content' <-- to jest ścieżka do tekstu w słowniku
}}</textarea>
```

`description` - parametr użyty już w samym partial tempalte.

**WAŻNE**
Białe znaki w `<textarea>` są drukowane w HTML, więc z tym trzeba ostrożnie. Już mi się podczas przenoszenia tekstów udało to popsuć i się dziwnie domyślna treść pokazywała na kartach na Stole.

Link do https://handlebarsjs.com/